### PR TITLE
Set the ConfigurableAccessTokenConverter to always extract the "sub" …

### DIFF
--- a/examples/siw-jquery/src/main/java/com/okta/spring/example/resources/WelcomeResource.java
+++ b/examples/siw-jquery/src/main/java/com/okta/spring/example/resources/WelcomeResource.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.xml.bind.annotation.XmlRootElement;
+import java.security.Principal;
 
 @RestController
 public class WelcomeResource {
@@ -31,16 +32,18 @@ public class WelcomeResource {
      */
     @GetMapping("/welcome")
     @PreAuthorize("#oauth2.clientHasRole('Everyone') || #oauth2.hasScope('email')")
-    public Welcome getMessageOfTheDay() {
-        return new Welcome("The message of the day is boring.");
+    public Welcome getMessageOfTheDay(Principal principal) {
+        return new Welcome("The message of the day is boring.", principal.getName());
     }
 
     @XmlRootElement
     public static class Welcome {
         public String messageOfTheDay;
+        public String username;
 
-        public Welcome(String messageOfTheDay) {
+        public Welcome(String messageOfTheDay, String username) {
             this.messageOfTheDay = messageOfTheDay;
+            this.username = username;
         }
     }
 }

--- a/examples/siw-jquery/src/main/resources/public/index.html
+++ b/examples/siw-jquery/src/main/resources/public/index.html
@@ -90,7 +90,7 @@
       },
     }).then(function(data) {
       // Render the message of the day
-      $('#cool-stuff-here').append(data.messageOfTheDay);
+      $('#cool-stuff-here').append(data.messageOfTheDay + "<br><strong>User:</strong> " + data.username);
     })
     .fail(function(data) {
       // handle any errors

--- a/okta-spring-security-starter/src/main/java/com/okta/spring/oauth/ConfigurableAccessTokenConverter.java
+++ b/okta-spring-security-starter/src/main/java/com/okta/spring/oauth/ConfigurableAccessTokenConverter.java
@@ -30,6 +30,8 @@ import java.util.Map;
  */
 public class ConfigurableAccessTokenConverter extends DefaultAccessTokenConverter {
 
+    private static final String SUBJECT_CLAIM = "sub";
+
     private final String scopeClaim;
     private final String rolesClaim;
 
@@ -54,6 +56,11 @@ public class ConfigurableAccessTokenConverter extends DefaultAccessTokenConverte
             if (!ObjectUtils.isEmpty(roles)) {
                 tokenMap.put(UserAuthenticationConverter.AUTHORITIES, roles);
             }
+        }
+
+        if (tokenMap.containsKey(SUBJECT_CLAIM)) {
+            Object sub = tokenMap.get(SUBJECT_CLAIM);
+            tokenMap.put(UserAuthenticationConverter.USERNAME, sub);
         }
 
         return tokenMap;

--- a/okta-spring-security-starter/src/test/groovy/com/okta/spring/oauth/ConfigurableAccessTokenConverterTest.groovy
+++ b/okta-spring-security-starter/src/test/groovy/com/okta/spring/oauth/ConfigurableAccessTokenConverterTest.groovy
@@ -106,7 +106,21 @@ class ConfigurableAccessTokenConverterTest {
                                             new SimpleGrantedAuthority("red_role"),
                                             new SimpleGrantedAuthority("blue_role")),
                                         hasSize(4))
+        assertThat auth.getUserAuthentication(), nullValue()
+    }
 
-
+    @Test
+    void extractSubject() {
+        def scopeClaim = "custom_scope"
+        def roleClaim = "custom_role"
+        def email = "joe.coder@example.com"
+        def converter = new ConfigurableAccessTokenConverter(scopeClaim, roleClaim)
+        def initialClaimMap = [
+                sub: email,
+                custom_scope: ["my_custom_scope", "as_an_array"],
+                custom_role: ["one_role", "two_role", "red_role", "blue_role"]
+        ]
+        def auth = converter.extractAuthentication(initialClaimMap)
+        assertThat auth.getUserAuthentication().name, equalTo(email)
     }
 }


### PR DESCRIPTION
…claim

This will setup the authentication object correct and mark the user as authenticated, it will also allow the principal (or Authentication) to be injected elsewhere.

Updated the WelcomeResource to take advantage of injecting the Principal