### PR TITLE
Cleanup CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,14 @@ before_install:
 script:
 - "./src/ci/build.sh"
 after_success:
-  - bash <(curl -s https://codecov.io/bash) -f okta-spring-security-starter/target/jacoco.exec
+  - bash <(curl -s https://codecov.io/bash) -f okta-spring-security-starter/target/site/jacoco/jacoco.xml
+
+deploy:
+  - provider: pages
+    skip_cleanup: true
+    github_token: $GH_API_KEY
+    local_dir: target/gh-pages
+    email: developers@okta.com
+    name: Travis CI - Auto Doc Build
+    on:
+      branch: master

--- a/okta-spring-security-starter/pom.xml
+++ b/okta-spring-security-starter/pom.xml
@@ -100,4 +100,22 @@
         </dependency>
 
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>jacoco-report</id>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                        <phase>verify</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/ci/build.sh
+++ b/src/ci/build.sh
@@ -34,9 +34,8 @@ else
         $MVN_CMD deploy -Pci
 
         # also deploy the javadocs to the site
-        git config --global user.email "developers@okta.com"
-        git config --global user.name "travis-ci Auto Doc Build"
-        $MVN_CMD javadoc:aggregate scm-publish:publish-scm -Ppub-docs -Pci
+        git clone -b gh-pages https://github.com/${REPO_SLUG}.git target/gh-pages/
+        $MVN_CMD javadoc:aggregate -Ppub-docs -Pci
     else
         # else try to run the ITs if possible (for someone who has push access to the repo
         if [ "$RUN_ITS" = true ] ; then


### PR DESCRIPTION
* Use travis deploy provider to deploy javadocs
* Generate the jacoco XML report for use with codecov