### PR TITLE
User details claims

### DIFF
--- a/integration-tests/oauth2/pom.xml
+++ b/integration-tests/oauth2/pom.xml
@@ -21,6 +21,7 @@
         <groupId>com.okta.spring</groupId>
         <artifactId>okta-spring-boot-parent</artifactId>
         <version>0.2.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
     </parent>
 
     <artifactId>okta-spring-boot-integration-tests-oauth2</artifactId>

--- a/oauth2/src/main/java/com/okta/spring/oauth/ConfigurableAccessTokenConverter.java
+++ b/oauth2/src/main/java/com/okta/spring/oauth/ConfigurableAccessTokenConverter.java
@@ -77,13 +77,17 @@ public class ConfigurableAccessTokenConverter extends DefaultAccessTokenConverte
 
     @Override
     public OAuth2Authentication extractAuthentication(Map<String, ?> map) {
+        // call super with the updated map
         OAuth2Authentication originalOAuth2Authentication = super.extractAuthentication(tweakScopeMap(map));
 
+        // If this token has UserAuthentication we need to rebuild it (we do not call setDetails() directly,
+        // as the implementation might change, currently it is a UsernamePasswordAuthenticationToken)
         Authentication originalUserAuthentication = originalOAuth2Authentication.getUserAuthentication();
         if (originalUserAuthentication != null) {
             UsernamePasswordAuthenticationToken newToken = new UsernamePasswordAuthenticationToken(originalUserAuthentication.getPrincipal(),
                     "N/A",
                     originalUserAuthentication.getAuthorities());
+            // now set the details on the new token directly, and return a new OAuth2Authentication
             newToken.setDetails(Collections.unmodifiableMap(map));
             return new OAuth2Authentication(originalOAuth2Authentication.getOAuth2Request(), newToken);
         }

--- a/oauth2/src/main/java/com/okta/spring/oauth/OktaTokenServicesConfig.java
+++ b/oauth2/src/main/java/com/okta/spring/oauth/OktaTokenServicesConfig.java
@@ -17,7 +17,6 @@ package com.okta.spring.oauth;
 
 
 import com.okta.spring.config.OktaOAuth2Properties;
-import com.okta.spring.oauth.implicit.ConfigurableAccessTokenConverter;
 import org.springframework.beans.InvalidPropertyException;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;

--- a/oauth2/src/test/groovy/com/okta/spring/oauth/ConfigurableAccessTokenConverterTest.groovy
+++ b/oauth2/src/test/groovy/com/okta/spring/oauth/ConfigurableAccessTokenConverterTest.groovy
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.okta.spring.oauth.implicit
+package com.okta.spring.oauth
 
+import com.okta.spring.oauth.ConfigurableAccessTokenConverter
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.oauth2.provider.token.UserAuthenticationConverter
 import org.testng.annotations.Test
@@ -131,5 +132,6 @@ class ConfigurableAccessTokenConverterTest {
         ]
         def auth = converter.extractAuthentication(initialClaimMap)
         assertThat auth.getUserAuthentication().name, equalTo(email)
+        assertThat auth.getUserAuthentication().details, equalTo(initialClaimMap)
     }
 }


### PR DESCRIPTION
Spring Security does this when validating tokens remotely, so we need to set the user details when validating locally.